### PR TITLE
Replace deprecated property name 'controllingAccounts'

### DIFF
--- a/create-profile/create-up.js
+++ b/create-profile/create-up.js
@@ -17,7 +17,7 @@ const lspFactory = new LSPFactory("https://rpc.l14.lukso.network", {
 // Step 3.3 - Deploy our Universal Profile
 async function createUniversalProfile() {
   const deployedContracts = await lspFactory.UniversalProfile.deploy({
-    controllingAccounts: [myEOA.address], // our EOA that will be controlling the UP
+    controllerAddresses: [myEOA.address], // our EOA that will be controlling the UP
     lsp3Profile: {
       name: "My Universal Profile",
       description: "My Cool Universal Profile",


### PR DESCRIPTION
Replace deprecated property name `controllingAccounts` with `controllerAddresses` in lspFactory UP deploy example