### PR TITLE
Align some inconsistencies regarding RPC endpoint and IPFS gateway

### DIFF
--- a/convenience/check_address.js
+++ b/convenience/check_address.js
@@ -1,9 +1,10 @@
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
+const SAMPLE_PROFILE_ADDRESS = "0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e";
+
 // Import and Network Setup
 const Web3 = require("web3");
-const web3 = new Web3("https://rpc.l14.lukso.network");
-
-// Static address
-const SAMPLE_PROFILE_ADDRESS = "0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e";
+const web3 = new Web3(RPC_ENDPOINT);
 
 /*
  * Check if input is a valid blockchain address

--- a/convenience/create-eoa.js
+++ b/convenience/create-eoa.js
@@ -1,5 +1,10 @@
-const Web3 = require("web3");
-const web3 = new Web3();
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 
+// Import and Network Setup
+const Web3 = require("web3");
+const web3 = new Web3(RPC_ENDPOINT);
+
+// Create EOA
 const myEOA = web3.eth.accounts.create();
 console.log(myEOA);

--- a/create-profile/create-up.js
+++ b/create-profile/create-up.js
@@ -1,17 +1,21 @@
-const Web3 = require("web3");
-const { LSPFactory } = require("@lukso/lsp-factory.js");
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
+const CHAIN_ID = 2828;
+const PRIVATE_KEY = "0x..."; // add the private key of your EOA from ../convenience/create-eoa.js
 
-const web3 = new Web3();
+// Import and Network Setup
+const { LSPFactory } = require("@lukso/lsp-factory.js");
+const Web3 = require("web3");
+const web3 = new Web3(RPC_ENDPOINT);
 
 // Step 3.1 - Load our Externally Owned Account (EOA)
-const PRIVATE_KEY = "0x..."; // add the private key of your EOA from ../convenience/create-eoa.js
 const myEOA = web3.eth.accounts.privateKeyToAccount(PRIVATE_KEY);
 
 // Step 3.2
 // Initialize the LSPFactory with the L14 RPC endpoint and your EOA's private key, which will deploy the UP smart contracts
-const lspFactory = new LSPFactory("https://rpc.l14.lukso.network", {
+const lspFactory = new LSPFactory(RPC_ENDPOINT, {
   deployKey: PRIVATE_KEY,
-  chainId: 22,
+  chainId: CHAIN_ID,
 });
 
 // Step 3.3 - Deploy our Universal Profile

--- a/extract-data/extract-asset-data.js
+++ b/extract-data/extract-asset-data.js
@@ -5,19 +5,17 @@ require("isomorphic-fetch");
 const LSP4schema = require("@erc725/erc725.js/schemas/LSP4DigitalAsset.json");
 const LSP4 = require("@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json");
 
-// Sample addresses
-const SAMPLE_ASSET_ADDRESS = "0x081d3f0bff8ae2339cb65113822eec1510704d5c";
-
-// Network and storage
-const RPC_ENDPOINT = "https://rpc.l14.lukso.network";
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_ASSET_ADDRESS = "0x081d3f0bff8ae2339cb65113822eec1510704d5c";
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l14.lukso.network");
+const web3 = new Web3(RPC_ENDPOINT);
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;

--- a/extract-data/extract-profile-data.js
+++ b/extract-data/extract-profile-data.js
@@ -3,10 +3,10 @@ const Web3 = require("web3");
 const { ERC725 } = require("@erc725/erc725.js");
 require("isomorphic-fetch");
 
-// Our static variables
-const SAMPLE_PROFILE_ADDRESS = "0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e";
-const RPC_ENDPOINT = "https://rpc.l14.lukso.network";
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0x0C03fBa782b07bCf810DEb3b7f0595024A444F4e";
 
 // Parameters for ERC725 Instance
 const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");

--- a/fetch-asset/current/01-fetch-received-assets.js
+++ b/fetch-asset/current/01-fetch-received-assets.js
@@ -4,12 +4,10 @@ const { ERC725 } = require("@erc725/erc725.js");
 require("isomorphic-fetch");
 const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");
 
-// Sample addresses
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
-
-// Network and storage
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
-const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs/";
+const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);

--- a/fetch-asset/current/02-fetch-issued-assets.js
+++ b/fetch-asset/current/02-fetch-issued-assets.js
@@ -4,12 +4,10 @@ const { ERC725 } = require("@erc725/erc725.js");
 require("isomorphic-fetch");
 const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");
 
-// Sample addresses
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
-
-// Network and storage
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
-const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs/";
+const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);

--- a/fetch-asset/current/03-fetch-owned-assets.js
+++ b/fetch-asset/current/03-fetch-owned-assets.js
@@ -5,19 +5,17 @@ require("isomorphic-fetch");
 const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");
 const LSP8 = require("@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json");
 
-// Sample Addresses
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
-
-// Network & Storage
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
-const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs/";
+const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
 
 // Parameters for ERC725 Instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l16.lukso.network");
+const web3 = new Web3(RPC_ENDPOINT);
 
 /*
  * Fetch the @param's Universal Profile's

--- a/fetch-asset/current/04-check-asset-interface.js
+++ b/fetch-asset/current/04-check-asset-interface.js
@@ -5,11 +5,12 @@ const {
   ERC725Y_INTERFACE_IDS,
 } = require("@erc725/erc725.js/build/main/src/lib/constants");
 
-// Sample addresses
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l16.lukso.network");
+const web3 = new Web3(RPC_ENDPOINT);
 
 /*
  * Check the ERC725Y interface of an asset

--- a/fetch-asset/current/05-get-asset-data.js
+++ b/fetch-asset/current/05-get-asset-data.js
@@ -3,11 +3,12 @@ const Web3 = require("web3");
 const LSP4schema = require("@erc725/erc725.js/schemas/LSP4DigitalAsset.json");
 const LSP4 = require("@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json");
 
-// Sample addresses
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l16.lukso.network");
+const web3 = new Web3(RPC_ENDPOINT);
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;

--- a/fetch-asset/current/06-decode-asset-data.js
+++ b/fetch-asset/current/06-decode-asset-data.js
@@ -4,19 +4,17 @@ const { ERC725 } = require("@erc725/erc725.js");
 const LSP4schema = require("@erc725/erc725.js/schemas/LSP4DigitalAsset.json");
 const LSP4 = require("@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json");
 
-// Sample addresses
-const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
-
-// Network and storage
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
-const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs/";
+const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l16.lukso.network");
+const web3 = new Web3(RPC_ENDPOINT);
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;

--- a/fetch-asset/current/07-get-asset-storage-link.js
+++ b/fetch-asset/current/07-get-asset-storage-link.js
@@ -4,19 +4,17 @@ const { ERC725 } = require("@erc725/erc725.js");
 const LSP4schema = require("@erc725/erc725.js/schemas/LSP4DigitalAsset.json");
 const LSP4 = require("@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json");
 
-// Sample addresses
-const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
-
-// Network and storage
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
-const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs/";
+const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l16.lukso.network");
+const web3 = new Web3(RPC_ENDPOINT);
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;

--- a/fetch-asset/current/08-fetch-asset-data.js
+++ b/fetch-asset/current/08-fetch-asset-data.js
@@ -5,19 +5,17 @@ require("isomorphic-fetch");
 const LSP4schema = require("@erc725/erc725.js/schemas/LSP4DigitalAsset.json");
 const LSP4 = require("@lukso/lsp-smart-contracts/artifacts/LSP4DigitalAssetMetadata.json");
 
-// Sample addresses
-const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
-
-// Network and storage
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l16.lukso.network");
+const web3 = new Web3(RPC_ENDPOINT);
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;

--- a/fetch-asset/current/read_asset_full.js
+++ b/fetch-asset/current/read_asset_full.js
@@ -10,20 +10,18 @@ const {
   ERC725Y_INTERFACE_IDS,
 } = require("@erc725/erc725.js/build/main/src/lib/constants");
 
-// Sample addresses
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
-const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
-
-// Network and storage
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
+const SAMPLE_ASSET_ADDRESS = "0x923F49Bac508E4Ec063ac097E00b4a3cAc68a353";
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);
 const config = { ipfsGateway: IPFS_GATEWAY };
 
 // Setup Web3
-const web3 = new Web3("https://rpc.l16.lukso.network");
+const web3 = new Web3(RPC_ENDPOINT);
 
 // Data keys for asset properties
 const TokenNameKey = LSP4schema[1].key;

--- a/fetch-profile/00-fetch-universal-receiver.js
+++ b/fetch-profile/00-fetch-universal-receiver.js
@@ -3,12 +3,10 @@ const Web3 = require("web3");
 const { ERC725 } = require("@erc725/erc725.js");
 const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");
 
-// Sample addresses
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
-
-// Network and storage
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
-const IPFS_GATEWAY = "https://cloudflare-ipfs.com/ipfs/";
+const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
 
 // Parameters for the ERC725 instance
 const provider = new Web3.providers.HttpProvider(RPC_ENDPOINT);

--- a/fetch-profile/01-fetch-profile.js
+++ b/fetch-profile/01-fetch-profile.js
@@ -3,10 +3,10 @@ const Web3 = require("web3");
 const { ERC725 } = require("@erc725/erc725.js");
 require("isomorphic-fetch");
 
-// Our static variables
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
 
 // Parameters for ERC725 Instance
 const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");

--- a/fetch-profile/02-fetch-profile-metadata.js
+++ b/fetch-profile/02-fetch-profile-metadata.js
@@ -3,10 +3,10 @@ const Web3 = require("web3");
 const { ERC725 } = require("@erc725/erc725.js");
 require("isomorphic-fetch");
 
-// Our static variables
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
 
 // Parameters for ERC725 Instance
 const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");

--- a/fetch-profile/read_profile_full.js
+++ b/fetch-profile/read_profile_full.js
@@ -3,10 +3,10 @@ const Web3 = require("web3");
 const { ERC725 } = require("@erc725/erc725.js");
 require("isomorphic-fetch");
 
-// Our static variables
-const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
+// Static variables
 const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
 const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
+const SAMPLE_PROFILE_ADDRESS = "0xa907c1904c22DFd37FF56c1f3c3d795682539196";
 
 // Parameters for ERC725 Instance
 const erc725schema = require("@erc725/erc725.js/schemas/LSP3UniversalProfileMetadata.json");

--- a/transfer-lyx/transfer-lyx.js
+++ b/transfer-lyx/transfer-lyx.js
@@ -2,12 +2,13 @@ const Web3 = require("web3");
 const UniversalProfile = require("@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json");
 const KeyManager = require("@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json");
 
-const web3 = new Web3("https://rpc.l14.lukso.network");
-
-const myUPAddress = "0x...";
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
+const UNIVERSAL_PROFILE_ADDRESS = "0x...";
+const web3 = new Web3(RPC_ENDPOINT);
 
 // 1. instantiate your contracts
-const myUP = new web3.eth.Contract(UniversalProfile.abi, myUPAddress);
+const myUP = new web3.eth.Contract(UniversalProfile.abi, UNIVERSAL_PROFILE_ADDRESS);
 
 // the KeyManager is the owner of the Universal Profile
 // so get the address of the KeyManager by calling the owner() function
@@ -15,6 +16,7 @@ const owner = myUP.methods.owner().call();
 
 const myKM = new web3.eth.Contract(KeyManager.abi, owner);
 
+// Set transaction parameters
 const OPERATION_CALL = 0;
 const recipient = "0x..."; // address the recipient (any address, including an other UP)
 const amount = web3.utils.toWei("3");

--- a/update-profile/update_up_full.js
+++ b/update-profile/update_up_full.js
@@ -5,20 +5,21 @@ const { LSPFactory } = require("@lukso/lsp-factory.js");
 const UniversalProfile = require("@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json");
 const KeyManager = require("@lukso/lsp-smart-contracts/artifacts/LSP6KeyManager.json");
 
-const web3 = new Web3("https://rpc.l14.lukso.network");
-
-// Constants
+// Static variables
+const RPC_ENDPOINT = "https://rpc.l16.lukso.network";
+const CHAIN_ID = 2828;
+const IPFS_GATEWAY = "https://2eff.lukso.dev/ipfs/";
 const PRIVATE_KEY = "0x..."; // from ../convenience/create-eoa.js
-const profileAddress = "0x...";
+const UNIVERSAL_PROFILE_ADDRESS = "0x...";
+
+const web3 = new Web3(RPC_ENDPOINT);
 
 // Step 1 - Create a new LSP3Profile JSON file
 const jsonFile = require("./sample-metadata.json");
 
-const provider = "https://rpc.l14.lukso.network"; // RPC provider url
-
-const lspFactory = new LSPFactory(provider, {
+const lspFactory = new LSPFactory(RPC_ENDPOINT, {
   deployKey: PRIVATE_KEY,
-  chainId: 22, // Chain Id of the network you want to deploy to
+  chainId: CHAIN_ID, // Chain Id of the network you want to deploy to
 });
 
 async function editProfileInfo() {
@@ -40,8 +41,8 @@ async function editProfileInfo() {
     },
   ];
 
-  const erc725 = new ERC725(schema, profileAddress, web3.currentProvider, {
-    ipfsGateway: "https://cloudflare-ipfs.com/ipfs/",
+  const erc725 = new ERC725(schema, UNIVERSAL_PROFILE_ADDRESS, web3.currentProvider, {
+    ipfsGateway: IPFS_GATEWAY,
   });
 
   // Step 3.2 - Encode the LSP3Profile data (to be written on our UP)
@@ -62,7 +63,7 @@ async function editProfileInfo() {
   // Step 4.2 - Create instances of our Contracts
   const universalProfileContract = new web3.eth.Contract(
     UniversalProfile.abi,
-    profileAddress
+    UNIVERSAL_PROFILE_ADDRESS
   );
 
   const keyManagerAddress = await universalProfileContract.methods


### PR DESCRIPTION
This PR includes the following changes to reduce some confusion when trying out the examples:

- Use the correct RPC endpoint for all L16 examples
- Use the correct IPFS gateway for all L16 examples
- Align the way the static variables are declared
- Use the static variable when declaring new web3 instance instead of passing in the RPC string again