### PR TITLE
Increase gas limit for lyx transfer

### DIFF
--- a/transfer-lyx/transfer-lyx.js
+++ b/transfer-lyx/transfer-lyx.js
@@ -34,5 +34,5 @@ const transferLYXPayload = await myUP.methods
 await myKM.execute(transferLYXPayload).send({
   // Connected wallet with EOA address that can send funds from UP
   from: "<my-wallet-address>",
-  gasLimit: 300_00,
+  gasLimit: 300_000,
 });

--- a/transfer-lyx/transfer-lyx.js
+++ b/transfer-lyx/transfer-lyx.js
@@ -31,7 +31,7 @@ const transferLYXPayload = await myUP.methods
   .encodeABI();
 
 // 3. execute the LYX transfer via the Key Manager
-await myKM.execute(transferLYXPayload).send({
+await myKM.methods.execute(transferLYXPayload).send({
   // Connected wallet with EOA address that can send funds from UP
   from: "<my-wallet-address>",
   gasLimit: 300_000,


### PR DESCRIPTION
- Change `gasLimit` to `300_000`
- Fix how execute is called on key manager instance