### PR TITLE
refactor: use lukso testnet rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ async function fetchJSONData() {
   const erc725js = new ERC725(
     lsp4Schema,
     '0x<asset-address>', // <== Change this line with the asset address
-    'https://4201.rpc.thirdweb.com',
+    'https://rpc.testnet.lukso.network',
     {
       ipfsGateway: 'https://api.universalprofile.cloud/ipfs',
     },

--- a/digital-assets/backend-token-transaction.ts
+++ b/digital-assets/backend-token-transaction.ts
@@ -3,7 +3,7 @@ import LSP7Mintable from '@lukso/lsp-smart-contracts/artifacts/LSP7Mintable.json
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 
 // Connect to the testnet
-const RPC_ENDPOINT = 'https://4201.rpc.thirdweb.com';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 const provider = new ethers.JsonRpcProvider(RPC_ENDPOINT);
 
 // Get the controller key of the Universal Profile

--- a/digital-assets/extract-asset-data.ts
+++ b/digital-assets/extract-asset-data.ts
@@ -3,7 +3,7 @@ import LSP4Schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 import { FetchDataOutput } from '@erc725/erc725.js/build/main/src/types/decodeData.js';
 
 // https://docs.lukso.tech/networks/mainnet/parameters
-const RPC_ENDPOINT = 'https://4201.rpc.thirdweb.com';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 const IPFS_GATEWAY = 'https://api.universalprofile.cloud/ipfs';
 
 // 💡 Note: You can debug any smart contract by using the ERC725 Tools

--- a/digital-assets/fetch-asset-data.ts
+++ b/digital-assets/fetch-asset-data.ts
@@ -6,7 +6,7 @@ async function fetchJSONData() {
   const erc725js = new ERC725(
     lsp4Schema,
     '0xbA712C92C6e10f22d7C737f9BC7dAa22B65548F7', // Asset address (LSP7 or LSP8)
-    'https://4201.rpc.thirdweb.com',
+    'https://rpc.testnet.lukso.network',
     {
       ipfsGateway: 'https://api.universalprofile.cloud/ipfs',
     },

--- a/digital-assets/fetch-tokenid-metadata.ts
+++ b/digital-assets/fetch-tokenid-metadata.ts
@@ -9,7 +9,7 @@ import {
 import lsp8Artifact from '@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableDigitalAsset.json';
 
 const SAMPLE_LSP8_ASSET = '0x8734600968c7e7193BB9B1b005677B4edBaDcD18';
-const RPC_URL = 'https://4201.rpc.thirdweb.com';
+const RPC_URL = 'https://rpc.testnet.lukso.network';
 
 const provider = new ethers.JsonRpcProvider(RPC_URL);
 

--- a/digital-assets/get-data-keys.ts
+++ b/digital-assets/get-data-keys.ts
@@ -5,7 +5,7 @@ import lsp4Schema from '@erc725/erc725.js/schemas/LSP4DigitalAsset.json';
 const erc725js = new ERC725(
   lsp4Schema,
   '0x0514A829C832639Afcc02D257154A9DaAD8fa21B', // LSP7 Address
-  'https://4201.rpc.thirdweb.com',
+  'https://rpc.testnet.lukso.network',
   {
     ipfsGateway: 'https://api.universalprofile.cloud/ipfs',
   },

--- a/digital-assets/tokenIdFormat.ts
+++ b/digital-assets/tokenIdFormat.ts
@@ -3,7 +3,7 @@ import lsp8Artifact from '@lukso/lsp-smart-contracts/artifacts/LSP8IdentifiableD
 import { ERC725YDataKeys } from '@lukso/lsp-smart-contracts';
 
 const SAMPLE_LSP8_ASSET = '0x8734600968c7e7193BB9B1b005677B4edBaDcD18';
-const RPC_URL = 'https://4201.rpc.thirdweb.com';
+const RPC_URL = 'https://rpc.testnet.lukso.network';
 
 const provider = new ethers.JsonRpcProvider(RPC_URL);
 

--- a/interface-detection/erc165-interface-check.ts
+++ b/interface-detection/erc165-interface-check.ts
@@ -13,7 +13,7 @@ const SAMPLE_ASSET_CONTRACT_ADDRESS =
   '0xbA712C92C6e10f22d7C737f9BC7dAa22B65548F7';
 
 // https://docs.lukso.tech/networks/mainnet/parameters
-const RPC_URL = 'https://4201.rpc.thirdweb.com';
+const RPC_URL = 'https://rpc.testnet.lukso.network';
 
 const myAsset = new ERC725(lsp4Schema, SAMPLE_ASSET_CONTRACT_ADDRESS, RPC_URL, {
   ipfsGateway: 'https://api.universalprofile.cloud/ipfs',

--- a/key-manager/execute-relay-call.ts
+++ b/key-manager/execute-relay-call.ts
@@ -7,7 +7,9 @@ import { EIP191Signer } from '@lukso/eip191-signer.js';
 // This is the version relative to the LSP25 standard, defined as the number 25.
 import { LSP25_VERSION } from '@lukso/lsp-smart-contracts/constants';
 
-const provider = new ethers.JsonRpcProvider('https://4201.rpc.thirdweb.com');
+const provider = new ethers.JsonRpcProvider(
+  'https://rpc.testnet.lukso.network',
+);
 const universalProfileAddress = '0x...';
 const recipientAddress = '0x...';
 

--- a/key-manager/grant-permissions.ts
+++ b/key-manager/grant-permissions.ts
@@ -4,7 +4,7 @@ import LSP6Schema from '@erc725/erc725.js/schemas/LSP6KeyManager.json';
 import UniversalProfileArtifact from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 
 const myUniversalProfileAddress = process.env.UP_ADDR || '';
-const RPC_ENDPOINT = 'https://4201.rpc.thirdweb.com';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 
 // Initialize erc725.js with the schemas of the permission data keys from LSP6 Key Manager
 const erc725 = new ERC725(LSP6Schema, myUniversalProfileAddress, RPC_ENDPOINT);

--- a/metadata-detection/digital-asset-check.ts
+++ b/metadata-detection/digital-asset-check.ts
@@ -9,7 +9,7 @@ const assetContractAddress = '0xbA712C92C6e10f22d7C737f9BC7dAa22B65548F7';
 const erc725js = new ERC725(
   lsp4Schema,
   assetContractAddress,
-  'https://4201.rpc.thirdweb.com',
+  'https://rpc.testnet.lukso.network',
   {},
 );
 

--- a/metadata-detection/profile-check.ts
+++ b/metadata-detection/profile-check.ts
@@ -10,7 +10,7 @@ const profileContractAddress = '0x9139def55c73c12bcda9c44f12326686e3948634';
 const erc725js = new ERC725(
   lsp3ProfileSchema,
   profileContractAddress,
-  'https://4201.rpc.thirdweb.com',
+  'https://rpc.testnet.lukso.network',
   {},
 );
 

--- a/metadata-detection/vault-check.ts
+++ b/metadata-detection/vault-check.ts
@@ -10,7 +10,7 @@ const vaultContractAddress = '0x9139def55c73c12bcda9c44f12326686e3948634';
 const erc725js = new ERC725(
   lsp9VaultSchema,
   vaultContractAddress,
-  'https://4201.rpc.thirdweb.com',
+  'https://rpc.testnet.lukso.network',
   {},
 );
 

--- a/smart-contracts-hardhat/hardhat.config.ts
+++ b/smart-contracts-hardhat/hardhat.config.ts
@@ -17,7 +17,7 @@ const config: HardhatUserConfig = {
   },
   networks: {
     luksoTestnet: {
-      url: 'https://4201.rpc.thirdweb.com',
+      url: 'https://rpc.testnet.lukso.network',
       chainId: 4201,
       accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
     },

--- a/transfer-lyx/backend-lyx-transaction.ts
+++ b/transfer-lyx/backend-lyx-transaction.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 import UniversalProfile from '@lukso/lsp-smart-contracts/artifacts/UniversalProfile.json';
 
 // Connect to the testnet
-const RPC_ENDPOINT = 'https://4201.rpc.thirdweb.com';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 const provider = new ethers.JsonRpcProvider(RPC_ENDPOINT);
 
 // Get the controller key of the Universal Profile

--- a/universal-profile/create-EOA.ts
+++ b/universal-profile/create-EOA.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 
 // Static variables
-const RPC_ENDPOINT = 'https://4201.rpc.thirdweb.com/';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network/';
 
 // Setup ethers.js provider
 const provider = new ethers.JsonRpcProvider(RPC_ENDPOINT);

--- a/universal-profile/extract-profile-data.ts
+++ b/universal-profile/extract-profile-data.ts
@@ -4,7 +4,7 @@ import 'isomorphic-fetch';
 import { FetchDataOutput } from '@erc725/erc725.js/build/main/src/types/decodeData.js';
 
 // Static variables
-const RPC_ENDPOINT = 'https://4201.rpc.thirdweb.com';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 const IPFS_GATEWAY = 'https://api.universalprofile.cloud/ipfs';
 const SAMPLE_PROFILE_ADDRESS = '0x9139def55c73c12bcda9c44f12326686e3948634';
 

--- a/universal-profile/fetch-profile-data.ts
+++ b/universal-profile/fetch-profile-data.ts
@@ -5,7 +5,7 @@ import lsp3ProfileSchema from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.jso
 const erc725js = new ERC725(
   lsp3ProfileSchema,
   '0xEda145b45f76EDB44F112B0d46654044E7B8F319', // UP Contract Address
-  'https://4201.rpc.thirdweb.com',
+  'https://rpc.testnet.lukso.network',
   {
     ipfsGateway: 'https://api.universalprofile.cloud/ipfs',
   },

--- a/universal-profile/get-controller-permissions.ts
+++ b/universal-profile/get-controller-permissions.ts
@@ -10,7 +10,7 @@ const erc725 = new ERC725(
   // Sample Profile Address
   '0xEda145b45f76EDB44F112B0d46654044E7B8F319',
   // LUKSO Testnet RPC
-  'https://4201.rpc.thirdweb.com',
+  'https://rpc.testnet.lukso.network',
 );
 
 // 💡 You can debug permissions from ERC725 Tools

--- a/universal-profile/get-data-keys.ts
+++ b/universal-profile/get-data-keys.ts
@@ -11,7 +11,7 @@ const myUniversalProfileAddress = '0x9139def55c73c12bcda9c44f12326686e3948634';
 const erc725js = new ERC725(
   lsp3ProfileSchema,
   myUniversalProfileAddress,
-  'https://4201.rpc.thirdweb.com',
+  'https://rpc.testnet.lukso.network',
   {
     ipfsGateway: 'https://api.universalprofile.cloud/ipfs',
   },

--- a/universal-profile/register-issued-assets-backend.ts
+++ b/universal-profile/register-issued-assets-backend.ts
@@ -30,7 +30,7 @@ const issuedAssets = [
 const UNIVERSAL_PROFILE_ADDRESS = process.env.UP_ADDR || '';
 const PRIVATE_KEY = process.env.PRIVATE_KEY || '';
 
-const RPC_ENDPOINT = 'https://4201.rpc.thirdweb.com';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 
 const provider = new ethers.JsonRpcProvider(RPC_ENDPOINT);
 const myWallet = new ethers.Wallet(PRIVATE_KEY, provider);

--- a/universal-profile/update-issued-assets-backend.ts
+++ b/universal-profile/update-issued-assets-backend.ts
@@ -29,7 +29,7 @@ const issuedAssets = [
 // Get the private key of a Universal Profile controller
 const UNIVERSAL_PROFILE_ADDRESS = process.env.UP_ADDR || '';
 const PRIVATE_KEY = process.env.PRIVATE_KEY || '';
-const RPC_ENDPOINT = 'https://4201.rpc.thirdweb.com';
+const RPC_ENDPOINT = 'https://rpc.testnet.lukso.network';
 
 const provider = new ethers.JsonRpcProvider(RPC_ENDPOINT);
 const myWallet = new ethers.Wallet(PRIVATE_KEY, provider);


### PR DESCRIPTION
# What does this PR introduce? 

- [x] Replace testnet rpc with `lukso` one since the `thirdweb` rpc is not supported anymore